### PR TITLE
relax json and faraday gem

### DIFF
--- a/mailosaur.gemspec
+++ b/mailosaur.gemspec
@@ -11,9 +11,9 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
 
   s.files       = Dir['LICENSE', 'README.md', 'lib/mailosaur.rb', 'lib/**/*']
-  s.add_dependency 'json', '~> 2.1.0'
+  s.add_dependency 'json', '<= 3.0', '>= 1.7.5'
   s.add_dependency 'ms_rest', '= 0.7.2'
-  s.add_dependency 'faraday', '~> 0.14.0'
+  s.add_dependency 'faraday', '<= 1.0', '>= 0.9.0'
   s.add_dependency 'faraday-cookie_jar', '~> 0.0.6'
 
   s.add_development_dependency 'rake', '>= 10.5.0'


### PR DESCRIPTION
Unless there is a reason to use a specific version, eg. the runtime dependency [faraday-cookie_jar](https://rubygems.org/gems/faraday-cookie_jar), only require faraday to be at least `faraday >= 0.7.4`

As there are too many gems out there haven't really caught up to the latest faraday gem (especially oauth2 and many more), it would be great to relax the dependencies of these gems for greater compatibility or provide a path to upgrade mailosaur gem