### PR TITLE
Use VERSION constant in gemspec as intended

### DIFF
--- a/lib/Mailosaur/version.rb
+++ b/lib/Mailosaur/version.rb
@@ -1,3 +1,3 @@
 module Mailosaur
-    VERSION = '5.0.0'
+  VERSION = '5.0.20'
 end

--- a/mailosaur.gemspec
+++ b/mailosaur.gemspec
@@ -1,7 +1,9 @@
 require 'rake'
+require './lib/Mailosaur/version'
+
 Gem::Specification.new do |s|
   s.name        = 'mailosaur'
-  s.version     = '5.0.0'
+  s.version     = Mailosaur::VERSION
   s.summary     = 'Ruby client library for Mailosaur'
   s.description = 'Ruby client library for Mailosaur.'
   s.authors     = ['Mailosaur Ltd']

--- a/test/version_test.rb
+++ b/test/version_test.rb
@@ -1,0 +1,7 @@
+module Mailosaur
+  class VersionTest < Test::Unit::TestCase
+    should "return a VERSION that is in the v5 range" do
+      assert_match('5', Mailosaur::VERSION)
+    end
+  end
+end


### PR DESCRIPTION
This will make it easier to build and test future versions of the gem
Also added a rudimentary test, which forces you to check the test criteria whenever you do a major release