### PR TITLE
Docs: README updates — inbox (server) terminology and dashboard links

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,21 +10,32 @@ Mailosaur lets you automate email and SMS tests as part of software development 
 
 This guide provides several key sections:
 
+- [Mailosaur - Ruby library · ](#mailosaur---ruby-library--)
   - [Get Started](#get-started)
-  - [Installation](#installation)
-  - [Set your API key](#set-your-api-key)
-  - [Create your code](#create-your-code)
-  - [API Reference](#api-reference)
+    - [Installation](#installation)
+    - [Set your API key](#set-your-api-key)
+    - [Create your code](#create-your-code)
+    - [API Reference](#api-reference)
   - [Creating an account](#creating-an-account)
   - [Test email addresses with Mailosaur](#test-email-addresses-with-mailosaur)
   - [Find an email](#find-an-email)
+    - [What is this code doing?](#what-is-this-code-doing)
+    - [My email wasn't found](#my-email-wasnt-found)
   - [Find an SMS message](#find-an-sms-message)
   - [Testing plain text content](#testing-plain-text-content)
+    - [Extracting verification codes from plain text](#extracting-verification-codes-from-plain-text)
   - [Testing HTML content](#testing-html-content)
+    - [Working with HTML using Nokogiri](#working-with-html-using-nokogiri)
   - [Working with hyperlinks](#working-with-hyperlinks)
+    - [Links in plain text (including SMS messages)](#links-in-plain-text-including-sms-messages)
   - [Working with attachments](#working-with-attachments)
+    - [Writing an attachment to disk](#writing-an-attachment-to-disk)
   - [Working with images and web beacons](#working-with-images-and-web-beacons)
+    - [Remotely-hosted images](#remotely-hosted-images)
+    - [Triggering web beacons](#triggering-web-beacons)
   - [Spam checking](#spam-checking)
+  - [Development](#development)
+  - [Contacting us](#contacting-us)
 
 You can find the full [Mailosaur documentation](https://mailosaur.com/docs/) on the website.
 
@@ -32,7 +43,7 @@ If you get stuck, just contact us at support@mailosaur.com.
 
 ### Installation
 
-```
+```sh
 gem install mailosaur
 ```
 
@@ -46,11 +57,11 @@ export MAILOSAUR_API_KEY='your-api-key-here'
 
 ### Create your code
 
-Then import the library into your code:
+Now import the library and create a client:
 
 ```ruby
 require 'mailosaur'
-mailosaur = Mailosaur::MailosaurClient.new()
+mailosaur = Mailosaur::MailosaurClient.new
 ```
 
 ### API Reference
@@ -58,7 +69,7 @@ mailosaur = Mailosaur::MailosaurClient.new()
 This library is powered by the Mailosaur [email & SMS testing API](https://mailosaur.com/docs/api/). You can easily check out the API itself by looking at our [API reference documentation](https://mailosaur.com/docs/api/) or via our Postman or Insomnia collections:
 
 [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/6961255-6cc72dff-f576-451a-9023-b82dec84f95d?action=collection%2Ffork&collection-url=entityId%3D6961255-6cc72dff-f576-451a-9023-b82dec84f95d%26entityType%3Dcollection%26workspaceId%3D386a4af1-4293-4197-8f40-0eb49f831325)
- [![Run in Insomnia}](https://insomnia.rest/images/run.svg)](https://insomnia.rest/run/?label=Mailosaur&uri=https%3A%2F%2Fmailosaur.com%2Finsomnia.json)
+ [![Run in Insomnia](https://insomnia.rest/images/run.svg)](https://insomnia.rest/run/?label=Mailosaur&uri=https%3A%2F%2Fmailosaur.com%2Finsomnia.json)
 
 ## Creating an account
 
@@ -93,13 +104,13 @@ In automated tests you will want to wait for a new email to arrive. This library
 ```ruby
 require 'mailosaur'
 
-mailosaur = Mailosaur::MailosaurClient.new()
+mailosaur = Mailosaur::MailosaurClient.new
 
 # See https://mailosaur.com/app/project/api
 server_id = "abc123"
 server_domain = "abc123.mailosaur.net"
 
-criteria = Mailosaur::Models::SearchCriteria.new()
+criteria = Mailosaur::Models::SearchCriteria.new
 criteria.sent_to = "anything@" + server_domain
 
 email = mailosaur.messages.get(server_id, criteria)
@@ -109,9 +120,26 @@ puts(email.subject) # "Hello world!"
 
 ### What is this code doing?
 
-1. Sets up an instance of `MailosaurClient` using the `MAILOSAUR_API_KEY` environment variable.
+1. Sets up an instance of `MailosaurClient`, reading the API key from the `MAILOSAUR_API_KEY` environment variable.
 2. Waits for an email to arrive at the server with ID `abc123`.
 3. Outputs the subject line of the email.
+
+### My email wasn't found
+
+First, check that the email you sent is visible in the [Mailosaur Dashboard](https://mailosaur.com/app/project/messages).
+
+If it is, the likely reason is that by default, `messages.get` only searches emails received by Mailosaur in the last 1 hour. You can override this behavior (see the `received_after` argument below), however we only recommend doing this during setup, as your tests will generally run faster with the default settings:
+
+```ruby
+require 'date'
+
+email = mailosaur.messages.get(
+  server_id,
+  criteria,
+  # Override received_after to search all messages since Jan 1st
+  received_after: DateTime.new(2021, 1, 1)
+)
+```
 
 ## Find an SMS message
 
@@ -122,11 +150,13 @@ If your account has [SMS testing](https://mailosaur.com/sms-testing/) enabled, y
 ```ruby
 require 'mailosaur'
 
-mailosaur = Mailosaur::MailosaurClient.new()
+mailosaur = Mailosaur::MailosaurClient.new
 
+# See https://mailosaur.com/app/project/api
 server_id = "abc123"
+server_domain = "abc123.mailosaur.net"
 
-criteria = Mailosaur::Models::SearchCriteria.new()
+criteria = Mailosaur::Models::SearchCriteria.new
 criteria.sent_to = "4471235554444"
 
 sms = mailosaur.messages.get(server_id, criteria)
@@ -169,9 +199,9 @@ Most emails also have an HTML body, as well as the plain text content. You can a
 puts(message.html.body) # "<html><head ..."
 ```
 
-### Working with HTML using nokogiri
+### Working with HTML using Nokogiri
 
-If you need to traverse the HTML content of an email. For example, finding an element via a CSS selector, you can use the [nokogiri](https://rubygems.org/gems/nokogiri) library.
+If you need to traverse the HTML content of an email — for example, finding an element via a CSS selector — you can use the [Nokogiri](https://rubygems.org/gems/nokogiri) library.
 
 ```sh
 gem install nokogiri
@@ -182,12 +212,12 @@ require 'nokogiri'
 
 # ...
 
-@doc = Nokogiri::HTML(message.html.body)
-el = @doc.css(".verification-code")
+doc = Nokogiri::HTML(message.html.body)
+el = doc.at_css(".verification-code")
 
 verification_code = el.text
 
-puts verification_code # "542163"
+puts(verification_code) # "542163"
 ```
 
 [Read more](https://mailosaur.com/docs/test-cases/html-content/)
@@ -207,7 +237,7 @@ puts(first_link.text) # "Google Search"
 puts(first_link.href) # "https://www.google.com/"
 ```
 
-**Important:** To ensure you always have valid emails. Mailosaur only extracts links that have been correctly marked up with `<a>` or `<area>` tags.
+**Important:** To ensure you always have valid emails, Mailosaur only extracts links that have been correctly marked up with `<a>` or `<area>` tags.
 
 ### Links in plain text (including SMS messages)
 
@@ -243,6 +273,15 @@ The `length` property returns the size of the attached file (in bytes):
 ```ruby
 first_attachment = message.attachments[0]
 puts(first_attachment.length) # 4028
+```
+
+### Writing an attachment to disk
+
+```ruby
+first_attachment = message.attachments[1]
+
+file_bytes = mailosaur.files.get_attachment(first_attachment.id)
+File.binwrite(first_attachment.file_name, file_bytes)
 ```
 
 ## Working with images and web beacons

--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ Create a [free trial account](https://mailosaur.com/app/signup) for Mailosaur vi
 
 Once you have this, navigate to the [API tab](https://mailosaur.com/app/project/api) to find the following values:
 
-- **Server ID** - Servers act like projects, which group your tests together. You need this ID whenever you interact with a server via the API.
-- **Server Domain** - Every server has its own domain name. You'll need this to send email to your server.
-- **API Key** - You can create an API key per server (recommended), or an account-level API key to use across your whole account. [Learn more about API keys](https://mailosaur.com/docs/managing-your-account/api-keys/).
+- **Server ID** - Inboxes (servers) act like projects, which group your tests together. You need this ID whenever you interact with an inbox (server) via the API.
+- **Server Domain** - Every inbox (server) has its own domain name. You'll need this to send email to your inbox (server).
+- **API Key** - You can create an API key per inbox (server) — recommended — or an account-level API key to use across your whole account. [Learn more about API keys](https://mailosaur.com/docs/managing-your-account/api-keys/).
 
 ## Test email addresses with Mailosaur
 
@@ -87,13 +87,13 @@ Mailosaur gives you an **unlimited number of test email addresses** - with no se
 
 Here's how it works:
 
-* When you create an account, you are given a server.
-* Every server has its own **Server Domain** name (e.g. `abc123.mailosaur.net`)
+* When you create an account, you are given an inbox (server).
+* Every inbox (server) has its own **Server Domain** name (e.g. `abc123.mailosaur.net`)
 * Any email address that ends with `@{YOUR_SERVER_DOMAIN}` will work with Mailosaur without any special setup. For example:
   * `build-423@abc123.mailosaur.net`
   * `john.smith@abc123.mailosaur.net`
   * `rAnDoM63423@abc123.mailosaur.net`
-* You can create more servers when you need them. Each one will have its own domain name.
+* You can create more inboxes (servers) when you need them. Each one will have its own domain name.
 
 ***Can't use test email addresses?** You can also [use SMTP to test email](https://mailosaur.com/docs/email-testing/sending-to-mailosaur/#sending-via-smtp). By connecting your product or website to Mailosaur via SMTP, Mailosaur will catch all email your application sends, regardless of the email address.*
 
@@ -121,7 +121,7 @@ puts(email.subject) # "Hello world!"
 ### What is this code doing?
 
 1. Sets up an instance of `MailosaurClient`, reading the API key from the `MAILOSAUR_API_KEY` environment variable.
-2. Waits for an email to arrive at the server with ID `abc123`.
+2. Waits for an email to arrive at the inbox (server) with ID `abc123`.
 3. Outputs the subject line of the email.
 
 ### My email wasn't found

--- a/README.md
+++ b/README.md
@@ -75,11 +75,11 @@ This library is powered by the Mailosaur [email & SMS testing API](https://mailo
 
 Create a [free trial account](https://mailosaur.com/app/signup) for Mailosaur via the website.
 
-Once you have this, navigate to the [API tab](https://mailosaur.com/app/project/api) to find the following values:
+To start testing you'll need three things:
 
-- **Server ID** - Inboxes (servers) act like projects, which group your tests together. You need this ID whenever you interact with an inbox (server) via the API.
-- **Server Domain** - Every inbox (server) has its own domain name. You'll need this to send email to your inbox (server).
-- **API Key** - You can create an API key per inbox (server) — recommended — or an account-level API key to use across your whole account. [Learn more about API keys](https://mailosaur.com/docs/managing-your-account/api-keys/).
+- **API key** - [manage API keys within the Mailosaur Dashboard](https://mailosaur.com/app/keys). You can scope a key to a single inbox (server) — recommended — or create an account-level key. [Learn more about API keys](https://mailosaur.com/docs/managing-your-account/api-keys/).
+- **Inbox (server) domain** - open [your inbox](https://mailosaur.com/app/servers/default) (server) within the Mailosaur Dashboard to see its domain name (e.g. `abc123.mailosaur.net`). You'll need this to send email to the inbox (server).
+- **Inbox (server) ID** - the first part of the inbox (server) domain. For `abc123.mailosaur.net` the ID is `abc123`. You need this whenever you interact with the inbox (server) via the API.
 
 ## Test email addresses with Mailosaur
 
@@ -88,7 +88,7 @@ Mailosaur gives you an **unlimited number of test email addresses** - with no se
 Here's how it works:
 
 * When you create an account, you are given an inbox (server).
-* Every inbox (server) has its own **Server Domain** name (e.g. `abc123.mailosaur.net`)
+* Every inbox (server) has its own domain name (e.g. `abc123.mailosaur.net`)
 * Any email address that ends with `@{YOUR_SERVER_DOMAIN}` will work with Mailosaur without any special setup. For example:
   * `build-423@abc123.mailosaur.net`
   * `john.smith@abc123.mailosaur.net`
@@ -106,7 +106,6 @@ require 'mailosaur'
 
 mailosaur = Mailosaur::MailosaurClient.new
 
-# See https://mailosaur.com/app/project/api
 server_id = "abc123"
 server_domain = "abc123.mailosaur.net"
 
@@ -152,7 +151,6 @@ require 'mailosaur'
 
 mailosaur = Mailosaur::MailosaurClient.new
 
-# See https://mailosaur.com/app/project/api
 server_id = "abc123"
 server_domain = "abc123.mailosaur.net"
 

--- a/README.md
+++ b/README.md
@@ -178,18 +178,15 @@ end
 
 ### Extracting verification codes from plain text
 
-You may have an email or SMS message that contains an account verification code, or some other one-time passcode. You can extract content like this using a simple regex.
-
-Here is how to extract a 6-digit numeric code:
+You may have an email or SMS message that contains an account verification code, or some other one-time passcode. Mailosaur automatically extracts these for you and makes them available via the `codes` array on the message content:
 
 ```ruby
 puts(message.text.body) # "Your access code is 243546."
 
-match = message.text.body.match(/([0-9]{6})/)
-puts(match[0]) # "243546"
+puts(message.text.codes[0].value) # "243546"
 ```
 
-[Read more](https://mailosaur.com/docs/test-cases/text-content/)
+[Read more](https://mailosaur.com/docs/automation/codes)
 
 ## Testing HTML content
 


### PR DESCRIPTION
## Summary

- README content improvements and clearer structure, including better documentation of message `codes`.
- Adopt **inbox (server)** terminology throughout the prose: lead with the product UI term "inbox" and gloss "(server)", so the documentation matches what users see in the dashboard.
- Update dashboard links for the new layout: API keys are managed at `/app/keys`, and an inbox's (server's) domain — from which the ID is derived — is read from the inbox (server) itself at `/app/servers`. The obsolete combined "API tab" (`/app/project/api`) is removed.

## Scope

- Documentation only — no code, public API, or behaviour changes.
- Code identifiers and the `MAILOSAUR_SERVER` environment variable are unchanged.
