### PR TITLE
Intellisense: doc comments and inbox (server) terminology

### DIFF
--- a/lib/Mailosaur/analysis.rb
+++ b/lib/Mailosaur/analysis.rb
@@ -1,8 +1,11 @@
 module Mailosaur
+  # Operations for analyzing the content and deliverability of an email, including SpamAssassin
+  # scoring and per-provider deliverability reports. Accessed via +client.analysis+.
   class Analysis
     #
     # Creates and initializes a new instance of the Analysis class.
-    # @param conn client connection.
+    # @param conn [Faraday::Connection] The client connection.
+    # @param handle_http_error [Method] Callback used to convert HTTP error responses into errors.
     #
     def initialize(conn, handle_http_error)
       @conn = conn
@@ -13,13 +16,11 @@ module Mailosaur
     attr_reader :conn
 
     #
-    # Perform a spam test
+    # Perform a spam analysis of an email.
     #
-    # Perform spam testing on the specified email
+    # @param email [String] The identifier of the message to be analyzed.
     #
-    # @param email The identifier of the email to be analyzed.
-    #
-    # @return [SpamAnalysisResult] operation results.
+    # @return [Mailosaur::Models::SpamAnalysisResult] The spam score and filter results.
     #
     def spam(email)
       response = conn.get "api/analysis/spam/#{email}"
@@ -29,13 +30,11 @@ module Mailosaur
     end
 
     #
-    # Perform a deliverability report
+    # Perform a deliverability report of an email.
     #
-    # Perform deliverability test on the specified email
+    # @param email [String] The identifier of the message to be analyzed.
     #
-    # @param email The identifier of the email to be analyzed.
-    #
-    # @return [DeliverabilityReport] operation results.
+    # @return [Mailosaur::Models::DeliverabilityReport] The deliverability report for the email.
     #
     def deliverability(email)
       response = conn.get "api/analysis/deliverability/#{email}"

--- a/lib/Mailosaur/devices.rb
+++ b/lib/Mailosaur/devices.rb
@@ -1,8 +1,12 @@
 module Mailosaur
+  # Operations for managing virtual security devices and retrieving their current one-time
+  # passwords (OTPs), used to automate testing of app-based multi-factor authentication.
+  # Accessed via +client.devices+.
   class Devices
     #
     # Creates and initializes a new instance of the Devices class.
-    # @param client connection.
+    # @param conn [Faraday::Connection] The client connection.
+    # @param handle_http_error [Method] Callback used to convert HTTP error responses into errors.
     #
     def initialize(conn, handle_http_error)
       @conn = conn
@@ -13,11 +17,9 @@ module Mailosaur
     attr_reader :conn
 
     #
-    # List all devices
-    #
     # Returns a list of your virtual security devices.
     #
-    # @return [DeviceListResult] operation results.
+    # @return [Mailosaur::Models::DeviceListResult] Your devices.
     #
     def list
       response = conn.get 'api/devices'
@@ -27,13 +29,12 @@ module Mailosaur
     end
 
     #
-    # Create a device
+    # Creates a new virtual security device.
     #
-    # Creates a new virtual security device and returns it.
+    # @param device_create_options [Mailosaur::Models::DeviceCreateOptions] Options used to
+    #   create a new Mailosaur virtual security device.
     #
-    # @param device_create_options [DeviceCreateOptions]
-    #
-    # @return [Device] operation results.
+    # @return [Mailosaur::Models::Device] The newly-created device.
     #
     def create(device_create_options)
       response = conn.post 'api/devices', device_create_options.to_json
@@ -43,13 +44,13 @@ module Mailosaur
     end
 
     #
-    # Retrieve OTP
+    # Retrieves the current one-time password for a saved device, or given base32-encoded
+    # shared secret.
     #
-    # Retrieves the current one-time password for a saved device, or given base32-encoded shared secret.
+    # @param query [String] Either the unique identifier of the device, or a base32-encoded
+    #   shared secret.
     #
-    # @param query [String] Either the unique identifier of the device, or a base32-encoded shared secret.
-    #
-    # @return [OtpResult] operation results.
+    # @return [Mailosaur::Models::OtpResult] The current one-time password.
     #
     def otp(query)
       if query.include? '-'
@@ -68,11 +69,11 @@ module Mailosaur
     end
 
     #
-    # Delete a device
+    # Permanently delete a virtual security device. This operation cannot be undone.
     #
-    # Permanently deletes a device. This operation cannot be undone.
+    # @param id [String] The unique identifier of the device.
     #
-    # @param id [String] The identifier of the device to be deleted.
+    # @return [nil] Once the device has been deleted.
     #
     def delete(id)
       response = conn.delete "api/devices/#{id}"

--- a/lib/Mailosaur/files.rb
+++ b/lib/Mailosaur/files.rb
@@ -1,8 +1,11 @@
 module Mailosaur
+  # Operations for downloading the raw content associated with a message — file attachments,
+  # the full EML source of an email, and rendered email previews. Accessed via +client.files+.
   class Files
     #
     # Creates and initializes a new instance of the Files class.
-    # @param client connection.
+    # @param conn [Faraday::Connection] The client connection.
+    # @param handle_http_error [Method] Callback used to convert HTTP error responses into errors.
     #
     def initialize(conn, handle_http_error)
       @conn = conn
@@ -13,14 +16,11 @@ module Mailosaur
     attr_reader :conn
 
     #
-    # Download an attachment
+    # Downloads a single attachment.
     #
-    # Downloads a single attachment. Simply supply the unique identifier for the
-    # required attachment.
+    # @param id [String] The identifier for the required attachment.
     #
-    # @param id The identifier of the attachment to be downloaded.
-    #
-    # @return [NOT_IMPLEMENTED] operation results.
+    # @return [String] The attachment's binary content.
     #
     def get_attachment(id)
       response = conn.get "api/files/attachments/#{id}"
@@ -29,14 +29,11 @@ module Mailosaur
     end
 
     #
-    # Download EML
+    # Downloads an EML file representing the specified email.
     #
-    # Downloads an EML file representing the specified email. Simply supply the
-    # unique identifier for the required email.
+    # @param id [String] The identifier for the required message.
     #
-    # @param id The identifier of the email to be downloaded.
-    #
-    # @return [NOT_IMPLEMENTED] operation results.
+    # @return [String] The raw EML content of the email.
     #
     def get_email(id)
       response = conn.get "api/files/email/#{id}"
@@ -45,14 +42,15 @@ module Mailosaur
     end
 
     #
-    # Download an email preview
-    #
     # Downloads a screenshot of your email rendered in a real email client. Simply supply
     # the unique identifier for the required preview.
     #
-    # @param id The identifier of the email preview to be downloaded.
+    # @param id [String] The identifier of the email preview to be downloaded.
     #
-    # @return [NOT_IMPLEMENTED] operation results.
+    # @return [String] The preview screenshot image content.
+    #
+    # @raise [Mailosaur::MailosaurError] With error code +preview_timeout+ if the preview is
+    #   not generated within the time limit.
     #
     def get_preview(id)
       timeout = 120_000

--- a/lib/Mailosaur/messages.rb
+++ b/lib/Mailosaur/messages.rb
@@ -1,10 +1,13 @@
 require 'uri'
 
 module Mailosaur
+  # Operations for finding, retrieving, creating, forwarding, replying to, and deleting the
+  # email and SMS messages received by your Mailosaur servers. Accessed via +client.messages+.
   class Messages
     #
     # Creates and initializes a new instance of the Messages class.
-    # @param client connection.
+    # @param conn [Faraday::Connection] The client connection.
+    # @param handle_http_error [Method] Callback used to convert HTTP error responses into errors.
     #
     def initialize(conn, handle_http_error)
       @conn = conn
@@ -15,22 +18,24 @@ module Mailosaur
     attr_reader :conn
 
     #
-    # Retrieve a message using search criteria
+    # Waits for a message to be found. Returns as soon as a message matching the specified
+    # search criteria is found. This is the most efficient method of looking up a message,
+    # therefore we recommend using it wherever possible.
     #
-    # Returns as soon as a message matching the specified search criteria is
-    # found. This is the most efficient method of looking up a message.
-    #
-    # @param server [String] The identifier of the server hosting the message.
-    # @param criteria [SearchCriteria] The search criteria to use in order to find
-    # a match.
+    # @param server [String] The unique identifier of the containing server.
+    # @param criteria [Mailosaur::Models::SearchCriteria] The criteria with which to find
+    #   messages during a search.
     # @param timeout [Integer] Specify how long to wait for a matching result
-    # (in milliseconds).
+    #   (in milliseconds).
     # @param received_after [DateTime] Limits results to only messages received
-    # after this date/time.
-    # @param dir [String] Optionally limits results based on the direction (`Sent`
-    # or `Received`), with the default being `Received`.
+    #   after this date/time.
+    # @param dir [String] Optionally limits results based on the direction (+Sent+
+    #   or +Received+), with the default being +Received+.
     #
-    # @return [Message] operation results.
+    # @return [Mailosaur::Models::Message] The first message matching the criteria.
+    #
+    # @raise [Mailosaur::MailosaurError] With error code +no_messages_found+ if no matching
+    #   message exists, or +search_timeout+ if no matching message arrives before the timeout elapses.
     #
     def get(server, criteria, timeout: 10_000, received_after: DateTime.now - (1.0 / 24), dir: nil)
       # Defaults timeout to 10s, receivedAfter to 1h
@@ -41,14 +46,12 @@ module Mailosaur
     end
 
     #
-    # Retrieve a message
+    # Retrieves the detail for a single message. Must be used in conjunction with either
+    # {#list} or {#search} in order to get the unique identifier for the required message.
     #
-    # Retrieves the detail for a single email message. Simply supply the unique
-    # identifier for the required message.
+    # @param id [String] The unique identifier of the message to be retrieved.
     #
-    # @param id The identifier of the email message to be retrieved.
-    #
-    # @return [Message] operation results.
+    # @return [Mailosaur::Models::Message] The full message.
     #
     def get_by_id(id)
       response = conn.get "api/messages/#{id}"
@@ -58,12 +61,12 @@ module Mailosaur
     end
 
     #
-    # Delete a message
+    # Permanently deletes a message. Also deletes any attachments related to the message.
+    # This operation cannot be undone.
     #
-    # Permanently deletes a message. This operation cannot be undone. Also deletes
-    # any attachments related to the message.
+    # @param id [String] The identifier for the message.
     #
-    # @param id The identifier of the message to be deleted.
+    # @return [nil] Once the message has been deleted.
     #
     def delete(id)
       response = conn.delete "api/messages/#{id}"
@@ -72,23 +75,21 @@ module Mailosaur
     end
 
     #
-    # List all messages
-    #
     # Returns a list of your messages in summary form. The summaries are returned
     # sorted by received date, with the most recently-received messages appearing
     # first.
     #
-    # @param server [String] The identifier of the server hosting the messages.
-    # @param page [Integer] Used in conjunction with `itemsPerPage` to support
-    # pagination.
+    # @param server [String] The unique identifier of the required server.
+    # @param page [Integer] Used in conjunction with +items_per_page+ to support
+    #   pagination.
     # @param items_per_page [Integer] A limit on the number of results to be
-    # returned per page. Can be set between 1 and 1000 items, the default is 50.
+    #   returned per page. Can be set between 1 and 1000 items, the default is 50.
     # @param received_after [DateTime] Limits results to only messages received
-    # after this date/time.
-    # @param dir [String] Optionally limits results based on the direction (`Sent`
-    # or `Received`), with the default being `Received`.
+    #   after this date/time.
+    # @param dir [String] Optionally limits results based on the direction (+Sent+
+    #   or +Received+), with the default being +Received+.
     #
-    # @return [MessageListResult] operation results.
+    # @return [Mailosaur::Models::MessageListResult] The message summaries.
     #
     def list(server, page: nil, items_per_page: nil, received_after: nil, dir: nil)
       url = "api/messages?server=#{server}"
@@ -106,12 +107,11 @@ module Mailosaur
     end
 
     #
-    # Delete all messages
+    # Permanently delete all messages within a server. This operation cannot be undone.
     #
-    # Permanently deletes all messages held by the specified server. This operation
-    # cannot be undone. Also deletes any attachments related to each message.
+    # @param server [String] The unique identifier of the server.
     #
-    # @param server [String] The identifier of the server to be emptied.
+    # @return [nil] Once all messages within the server have been deleted.
     #
     def delete_all(server)
       response = conn.delete "api/messages?server=#{server}"
@@ -120,29 +120,30 @@ module Mailosaur
     end
 
     #
-    # Search for messages
-    #
     # Returns a list of messages matching the specified search criteria, in summary
     # form. The messages are returned sorted by received date, with the most
     # recently-received messages appearing first.
     #
-    # @param server [String] The identifier of the server hosting the messages.
-    # @param criteria [SearchCriteria] The search criteria to match results
-    # against.
-    # @param page [Integer] Used in conjunction with `itemsPerPage` to support
-    # pagination.
+    # @param server [String] The unique identifier of the server to search.
+    # @param criteria [Mailosaur::Models::SearchCriteria] The criteria with which to find
+    #   messages during a search.
+    # @param page [Integer] Used in conjunction with +items_per_page+ to support
+    #   pagination.
     # @param items_per_page [Integer] A limit on the number of results to be
-    # returned per page. Can be set between 1 and 1000 items, the default is 50.
+    #   returned per page. Can be set between 1 and 1000 items, the default is 50.
     # @param timeout [Integer] Specify how long to wait for a matching result
-    # (in milliseconds).
+    #   (in milliseconds).
     # @param received_after [DateTime] Limits results to only messages received
-    # after this date/time.
+    #   after this date/time.
     # @param error_on_timeout [Boolean] When set to false, an error will not be
-    # throw if timeout is reached (default: true).
-    # @param dir [String] Optionally limits results based on the direction (`Sent`
-    # or `Received`), with the default being `Received`.
+    #   raised if the timeout is reached (default: true).
+    # @param dir [String] Optionally limits results based on the direction (+Sent+
+    #   or +Received+), with the default being +Received+.
     #
-    # @return [MessageListResult] operation results.
+    # @return [Mailosaur::Models::MessageListResult] The matching message summaries.
+    #
+    # @raise [Mailosaur::MailosaurError] With error code +search_timeout+ if no matching message
+    #   is found before the timeout elapses, unless +error_on_timeout+ is set to false.
     #
     def search(server, criteria, page: nil, items_per_page: nil, timeout: nil, received_after: nil, error_on_timeout: true, dir: nil)
       url = "api/messages/search?server=#{server}"
@@ -182,16 +183,15 @@ module Mailosaur
     end
 
     #
-    # Create a message.
-    #
     # Creates a new message that can be sent to a verified email address. This is
     # useful in scenarios where you want an email to trigger a workflow in your
-    # product
+    # product.
     #
-    # @param server [String] The identifier of the server to create the message in.
-    # @param options [MessageCreateOptions] The options with which to create the message.
+    # @param server [String] The unique identifier of the required server.
+    # @param message_create_options [Mailosaur::Models::MessageCreateOptions] Options to use
+    #   when creating a new message.
     #
-    # @return [Message] operation result.
+    # @return [Mailosaur::Models::Message] The newly-created message.
     #
     def create(server, message_create_options)
       response = conn.post "api/messages?server=#{server}", message_create_options.to_json
@@ -201,15 +201,14 @@ module Mailosaur
     end
 
     #
-    # Forward an email.
+    # Forwards the specified message to a verified email address. This is useful for
+    # simulating a user forwarding one of your email messages.
     #
-    # Forwards the specified email to a verified email address.
+    # @param id [String] The unique identifier of the message to be forwarded.
+    # @param message_forward_options [Mailosaur::Models::MessageForwardOptions] Options to use
+    #   when forwarding a message.
     #
-    # @param id [String] The identifier of the email to forward.
-    # @param options [MessageForwardOptions] The options with which to forward the email.
-    # against.
-    #
-    # @return [Message] operation result.
+    # @return [Mailosaur::Models::Message] The forwarded message.
     #
     def forward(id, message_forward_options)
       response = conn.post "api/messages/#{id}/forward", message_forward_options.to_json
@@ -219,16 +218,14 @@ module Mailosaur
     end
 
     #
-    # Reply to an email.
+    # Sends a reply to the specified message. This is useful for when simulating a user
+    # replying to one of your email or SMS messages.
     #
-    # Sends a reply to the specified email. This is useful for when simulating a user
-    # replying to one of your emails.
+    # @param id [String] The unique identifier of the message to be replied to.
+    # @param message_reply_options [Mailosaur::Models::MessageReplyOptions] Options to use
+    #   when replying to a message.
     #
-    # @param id [String] The identifier of the email to reply to.
-    # @param options [MessageReplyOptions] The options with which to reply to the email.
-    # against.
-    #
-    # @return [Message] operation result.
+    # @return [Mailosaur::Models::Message] The reply message.
     #
     def reply(id, message_reply_options)
       response = conn.post "api/messages/#{id}/reply", message_reply_options.to_json
@@ -238,14 +235,13 @@ module Mailosaur
     end
 
     #
-    # Generate email previews.
-    #
     # Generates screenshots of an email rendered in the specified email clients.
     #
     # @param id [String] The identifier of the email to preview.
-    # @param options [PreviewRequestOptions] The options with which to generate previews.
+    # @param options [Mailosaur::Models::PreviewRequestOptions] The options with which to
+    #   generate previews.
     #
-    # @return [PreviewListResult] operation result.
+    # @return [Mailosaur::Models::PreviewListResult] The generated previews.
     #
     def generate_previews(id, options)
       response = conn.post "api/messages/#{id}/screenshots", options.to_json

--- a/lib/Mailosaur/messages.rb
+++ b/lib/Mailosaur/messages.rb
@@ -2,7 +2,7 @@ require 'uri'
 
 module Mailosaur
   # Operations for finding, retrieving, creating, forwarding, replying to, and deleting the
-  # email and SMS messages received by your Mailosaur servers. Accessed via +client.messages+.
+  # email and SMS messages received by your Mailosaur inboxes (servers). Accessed via +client.messages+.
   class Messages
     #
     # Creates and initializes a new instance of the Messages class.
@@ -22,7 +22,7 @@ module Mailosaur
     # search criteria is found. This is the most efficient method of looking up a message,
     # therefore we recommend using it wherever possible.
     #
-    # @param server [String] The unique identifier of the containing server.
+    # @param server [String] The unique identifier of the containing inbox (server).
     # @param criteria [Mailosaur::Models::SearchCriteria] The criteria with which to find
     #   messages during a search.
     # @param timeout [Integer] Specify how long to wait for a matching result
@@ -79,7 +79,7 @@ module Mailosaur
     # sorted by received date, with the most recently-received messages appearing
     # first.
     #
-    # @param server [String] The unique identifier of the required server.
+    # @param server [String] The unique identifier of the required inbox (server).
     # @param page [Integer] Used in conjunction with +items_per_page+ to support
     #   pagination.
     # @param items_per_page [Integer] A limit on the number of results to be
@@ -107,11 +107,11 @@ module Mailosaur
     end
 
     #
-    # Permanently delete all messages within a server. This operation cannot be undone.
+    # Permanently delete all messages within an inbox (server). This operation cannot be undone.
     #
-    # @param server [String] The unique identifier of the server.
+    # @param server [String] The unique identifier of the inbox (server).
     #
-    # @return [nil] Once all messages within the server have been deleted.
+    # @return [nil] Once all messages within the inbox (server) have been deleted.
     #
     def delete_all(server)
       response = conn.delete "api/messages?server=#{server}"
@@ -124,7 +124,7 @@ module Mailosaur
     # form. The messages are returned sorted by received date, with the most
     # recently-received messages appearing first.
     #
-    # @param server [String] The unique identifier of the server to search.
+    # @param server [String] The unique identifier of the inbox (server) to search.
     # @param criteria [Mailosaur::Models::SearchCriteria] The criteria with which to find
     #   messages during a search.
     # @param page [Integer] Used in conjunction with +items_per_page+ to support
@@ -187,7 +187,7 @@ module Mailosaur
     # useful in scenarios where you want an email to trigger a workflow in your
     # product.
     #
-    # @param server [String] The unique identifier of the required server.
+    # @param server [String] The unique identifier of the required inbox (server).
     # @param message_create_options [Mailosaur::Models::MessageCreateOptions] Options to use
     #   when creating a new message.
     #

--- a/lib/Mailosaur/models/message.rb
+++ b/lib/Mailosaur/models/message.rb
@@ -63,7 +63,7 @@ module Mailosaur
       # @return [Metadata]
       attr_accessor :metadata
 
-      # @return [String] Identifier for the server in which the message is
+      # @return [String] Identifier for the inbox (server) in which the message is
       # located.
       attr_accessor :server
     end

--- a/lib/Mailosaur/models/server.rb
+++ b/lib/Mailosaur/models/server.rb
@@ -8,17 +8,17 @@ module Mailosaur
         @messages = data['messages']
       end
 
-      # @return [String] Unique identifier for the server. Used as username for
+      # @return [String] Unique identifier for the inbox (server). Used as username for
       # SMTP/POP3 authentication.
       attr_accessor :id
 
-      # @return [String] A name used to identify the server.
+      # @return [String] A name used to identify the inbox (server).
       attr_accessor :name
 
-      # @return Users (excluding administrators) who have access to the server.
+      # @return Users (excluding administrators) who have access to the inbox (server) when access is restricted.
       attr_accessor :users
 
-      # @return [Integer] The number of messages currently in the server.
+      # @return [Integer] The number of messages currently in the inbox (server).
       attr_accessor :messages
     end
   end

--- a/lib/Mailosaur/models/server_create_options.rb
+++ b/lib/Mailosaur/models/server_create_options.rb
@@ -5,7 +5,7 @@ module Mailosaur
         @name = data['name']
       end
 
-      # @return [String] A name used to identify the server.
+      # @return [String] A name used to identify the inbox (server).
       attr_accessor :name
     end
   end

--- a/lib/Mailosaur/models/server_list_result.rb
+++ b/lib/Mailosaur/models/server_list_result.rb
@@ -6,9 +6,9 @@ module Mailosaur
         (data['items'] || []).each do |i| @items << Mailosaur::Models::Server.new(i) end
       end
 
-      # @return [Array<Server>] The individual servers forming the result.
-      # Servers are returned sorted by creation date, with the most
-      # recently-created server appearing first.
+      # @return [Array<Server>] The individual inboxes (servers) forming the result.
+      # Inboxes (servers) are returned sorted by creation date, with the most
+      # recently-created inbox (server) appearing first.
       attr_accessor :items
     end
   end

--- a/lib/Mailosaur/previews.rb
+++ b/lib/Mailosaur/previews.rb
@@ -1,8 +1,11 @@
 module Mailosaur
+  # Operations for discovering the email clients available for generating email previews
+  # (screenshots of an email rendered in real clients). Accessed via +client.previews+.
   class Previews
     #
     # Creates and initializes a new instance of the Previews class.
-    # @param client connection.
+    # @param conn [Faraday::Connection] The client connection.
+    # @param handle_http_error [Method] Callback used to convert HTTP error responses into errors.
     #
     def initialize(conn, handle_http_error)
       @conn = conn
@@ -15,9 +18,7 @@ module Mailosaur
     #
     # List all email clients that can be used to generate email previews.
     #
-    # Returns a list of available email clients.
-    #
-    # @return [EmailClientListResult] operation results.
+    # @return [Mailosaur::Models::EmailClientListResult] The available email clients.
     #
     def list_email_clients
       response = conn.get 'api/screenshots/clients'

--- a/lib/Mailosaur/servers.rb
+++ b/lib/Mailosaur/servers.rb
@@ -1,8 +1,12 @@
 module Mailosaur
+  # Operations for creating and managing your Mailosaur servers — the virtual inboxes that
+  # group your tests together, each with its own domain and SMTP/POP3/IMAP credentials.
+  # Accessed via +client.servers+.
   class Servers
     #
     # Creates and initializes a new instance of the Servers class.
-    # @param client connection.
+    # @param conn [Faraday::Connection] The client connection.
+    # @param handle_http_error [Method] Callback used to convert HTTP error responses into errors.
     #
     def initialize(conn, handle_http_error)
       @conn = conn
@@ -13,12 +17,10 @@ module Mailosaur
     attr_reader :conn
 
     #
-    # List all servers
-    #
-    # Returns a list of your virtual SMTP servers. Servers are returned sorted in
+    # Returns a list of your virtual servers. Servers are returned sorted in
     # alphabetical order.
     #
-    # @return [ServerListResult] operation results.
+    # @return [Mailosaur::Models::ServerListResult] Your servers.
     #
     def list
       response = conn.get 'api/servers'
@@ -28,13 +30,12 @@ module Mailosaur
     end
 
     #
-    # Create a server
+    # Creates a new virtual server.
     #
-    # Creates a new virtual SMTP server and returns it.
+    # @param server_create_options [Mailosaur::Models::ServerCreateOptions] Options used to
+    #   create a new Mailosaur server.
     #
-    # @param server_create_options [ServerCreateOptions]
-    #
-    # @return [Server] operation results.
+    # @return [Mailosaur::Models::Server] The newly-created server.
     #
     def create(server_create_options)
       response = conn.post 'api/servers', server_create_options.to_json
@@ -44,14 +45,11 @@ module Mailosaur
     end
 
     #
-    # Retrieve a server
+    # Retrieves the detail for a single server.
     #
-    # Retrieves the detail for a single server. Simply supply the unique identifier
-    # for the required server.
+    # @param id [String] The unique identifier of the server.
     #
-    # @param id [String] The identifier of the server to be retrieved.
-    #
-    # @return [Server] operation results.
+    # @return [Mailosaur::Models::Server] The server.
     #
     def get(id)
       response = conn.get "api/servers/#{id}"
@@ -61,14 +59,12 @@ module Mailosaur
     end
 
     #
-    # Retrieve server password
+    # Retrieves the password for a server. This password can be used for SMTP, POP3, and
+    # IMAP connectivity.
     #
-    # Retrieves the password for use with SMTP and POP3 for a single server.
-    # Simply supply the unique identifier for the required server.
+    # @param id [String] The unique identifier of the server.
     #
-    # @param id [String] The identifier of the server.
-    #
-    # @return [String] Server password.
+    # @return [String] The server's password.
     #
     def get_password(id)
       response = conn.get "api/servers/#{id}/password"
@@ -78,14 +74,12 @@ module Mailosaur
     end
 
     #
-    # Update a server
+    # Updates the attributes of a server.
     #
-    # Updats a single server and returns it.
+    # @param id [String] The unique identifier of the server.
+    # @param server [Mailosaur::Models::Server] The updated server.
     #
-    # @param id [String] The identifier of the server to be updated.
-    # @param server [Server]
-    #
-    # @return [Server] operation results.
+    # @return [Mailosaur::Models::Server] The updated server.
     #
     def update(id, server)
       response = conn.put "api/servers/#{id}", server.to_json
@@ -95,12 +89,12 @@ module Mailosaur
     end
 
     #
-    # Delete a server
+    # Permanently delete a server. This will also delete all messages, associated attachments,
+    # etc. within the server. This operation cannot be undone.
     #
-    # Permanently deletes a server. This operation cannot be undone. Also deletes
-    # all messages and associated attachments within the server.
+    # @param id [String] The unique identifier of the server.
     #
-    # @param id [String] The identifier of the server to be deleted.
+    # @return [nil] Once the server has been deleted.
     #
     def delete(id)
       response = conn.delete "api/servers/#{id}"
@@ -108,6 +102,14 @@ module Mailosaur
       nil
     end
 
+    #
+    # Generates a random email address by appending a random string in front of the server's
+    # domain name.
+    #
+    # @param server [String] The identifier of the server.
+    #
+    # @return [String] A random email address ending in the server's domain.
+    #
     def generate_email_address(server)
       host = ENV['MAILOSAUR_SMTP_HOST'] || 'mailosaur.net'
       format('%s@%s.%s', SecureRandom.hex(3), server, host)

--- a/lib/Mailosaur/servers.rb
+++ b/lib/Mailosaur/servers.rb
@@ -1,5 +1,5 @@
 module Mailosaur
-  # Operations for creating and managing your Mailosaur servers — the virtual inboxes that
+  # Operations for creating and managing your Mailosaur inboxes (servers) — they
   # group your tests together, each with its own domain and SMTP/POP3/IMAP credentials.
   # Accessed via +client.servers+.
   class Servers
@@ -17,10 +17,10 @@ module Mailosaur
     attr_reader :conn
 
     #
-    # Returns a list of your virtual servers. Servers are returned sorted in
+    # Returns a list of your inboxes (servers). Inboxes (servers) are returned sorted in
     # alphabetical order.
     #
-    # @return [Mailosaur::Models::ServerListResult] Your servers.
+    # @return [Mailosaur::Models::ServerListResult] Your inboxes (servers).
     #
     def list
       response = conn.get 'api/servers'
@@ -30,12 +30,12 @@ module Mailosaur
     end
 
     #
-    # Creates a new virtual server.
+    # Creates a new inbox (server).
     #
     # @param server_create_options [Mailosaur::Models::ServerCreateOptions] Options used to
-    #   create a new Mailosaur server.
+    #   create a new Mailosaur inbox (server).
     #
-    # @return [Mailosaur::Models::Server] The newly-created server.
+    # @return [Mailosaur::Models::Server] The newly-created inbox (server).
     #
     def create(server_create_options)
       response = conn.post 'api/servers', server_create_options.to_json
@@ -45,11 +45,11 @@ module Mailosaur
     end
 
     #
-    # Retrieves the detail for a single server.
+    # Retrieves the detail for a single inbox (server).
     #
-    # @param id [String] The unique identifier of the server.
+    # @param id [String] The unique identifier of the inbox (server).
     #
-    # @return [Mailosaur::Models::Server] The server.
+    # @return [Mailosaur::Models::Server] The inbox (server).
     #
     def get(id)
       response = conn.get "api/servers/#{id}"
@@ -59,12 +59,12 @@ module Mailosaur
     end
 
     #
-    # Retrieves the password for a server. This password can be used for SMTP, POP3, and
+    # Retrieves the password for an inbox (server). This password can be used for SMTP, POP3, and
     # IMAP connectivity.
     #
-    # @param id [String] The unique identifier of the server.
+    # @param id [String] The unique identifier of the inbox (server).
     #
-    # @return [String] The server's password.
+    # @return [String] The password for the inbox (server).
     #
     def get_password(id)
       response = conn.get "api/servers/#{id}/password"
@@ -74,12 +74,12 @@ module Mailosaur
     end
 
     #
-    # Updates the attributes of a server.
+    # Updates the attributes of an inbox (server).
     #
-    # @param id [String] The unique identifier of the server.
-    # @param server [Mailosaur::Models::Server] The updated server.
+    # @param id [String] The unique identifier of the inbox (server).
+    # @param server [Mailosaur::Models::Server] The updated inbox (server).
     #
-    # @return [Mailosaur::Models::Server] The updated server.
+    # @return [Mailosaur::Models::Server] The updated inbox (server).
     #
     def update(id, server)
       response = conn.put "api/servers/#{id}", server.to_json
@@ -89,12 +89,12 @@ module Mailosaur
     end
 
     #
-    # Permanently delete a server. This will also delete all messages, associated attachments,
-    # etc. within the server. This operation cannot be undone.
+    # Permanently delete an inbox (server). This will also delete all messages, associated attachments,
+    # etc. within the inbox (server). This operation cannot be undone.
     #
-    # @param id [String] The unique identifier of the server.
+    # @param id [String] The unique identifier of the inbox (server).
     #
-    # @return [nil] Once the server has been deleted.
+    # @return [nil] Once the inbox (server) has been deleted.
     #
     def delete(id)
       response = conn.delete "api/servers/#{id}"
@@ -103,12 +103,12 @@ module Mailosaur
     end
 
     #
-    # Generates a random email address by appending a random string in front of the server's
-    # domain name.
+    # Generates a random email address by appending a random string in front of the
+    # domain name of the inbox (server).
     #
-    # @param server [String] The identifier of the server.
+    # @param server [String] The identifier of the inbox (server).
     #
-    # @return [String] A random email address ending in the server's domain.
+    # @return [String] A random email address ending in the domain of the inbox (server).
     #
     def generate_email_address(server)
       host = ENV['MAILOSAUR_SMTP_HOST'] || 'mailosaur.net'

--- a/lib/Mailosaur/usage.rb
+++ b/lib/Mailosaur/usage.rb
@@ -1,8 +1,11 @@
 module Mailosaur
+  # Operations for inspecting your account's usage limits and recent transactional usage.
+  # These endpoints require authentication with an account-level API key. Accessed via +client.usage+.
   class Usage
     #
     # Creates and initializes a new instance of the Usage class.
-    # @param client connection.
+    # @param conn [Faraday::Connection] The client connection.
+    # @param handle_http_error [Method] Callback used to convert HTTP error responses into errors.
     #
     def initialize(conn, handle_http_error)
       @conn = conn
@@ -13,11 +16,10 @@ module Mailosaur
     attr_reader :conn
 
     #
-    # Retrieve account usage limits.
+    # Retrieve account usage limits. Details the current limits and usage for your account.
+    # This endpoint requires authentication with an account-level API key.
     #
-    # Details the current limits and usage for your account.
-    #
-    # @return [UsageAccountLimits] operation results.
+    # @return [Mailosaur::Models::UsageAccountLimits] The usage limits for your account.
     #
     def limits
       response = conn.get 'api/usage/limits'
@@ -27,9 +29,10 @@ module Mailosaur
     end
 
     #
-    # List account transactions. Retrieves the last 31 days of transactional usage.
+    # Retrieves the last 31 days of transactional usage.
+    # This endpoint requires authentication with an account-level API key.
     #
-    # @return [UsageTransactionListResult] operation results.
+    # @return [Mailosaur::Models::UsageTransactionListResult] The transactional usage for the last 31 days.
     #
     def transactions
       response = conn.get 'api/usage/transactions'

--- a/lib/mailosaur.rb
+++ b/lib/mailosaur.rb
@@ -100,7 +100,7 @@ module Mailosaur
       @messages ||= Messages.new(connection, method(:handle_http_error))
     end
 
-    # Operations for creating and managing your Mailosaur servers (virtual inboxes).
+    # Operations for creating and managing your Mailosaur inboxes (servers).
     # @return [Servers] the servers operations namespace.
     def servers
       @servers ||= Servers.new(connection, method(:handle_http_error))

--- a/lib/mailosaur.rb
+++ b/lib/mailosaur.rb
@@ -62,11 +62,16 @@ module Mailosaur
     autoload :BaseModel,                                          'Mailosaur/models/base_model.rb'
   end
 
+  # The Mailosaur client — the main entry point to the Mailosaur API. Construct an instance with
+  # your API key (or set the +MAILOSAUR_API_KEY+ environment variable), then use the operations
+  # namespaces (+messages+, +servers+, +files+, +devices+, +analysis+, +previews+, +usage+) to
+  # automate email and SMS testing.
   class MailosaurClient
     #
-    # Creates initializes a new instance of the MailosaurClient class.
+    # Returns an instance of the Mailosaur client.
     # @param api_key [String] Optional API key. Overrides the MAILOSAUR_API_KEY environment variable if set.
-    # @param base_url [String] the base URI of the service.
+    # @param base_url [String] Optionally overrides the base URL of the Mailosaur service.
+    # @raise [ArgumentError] If no API key is provided and the MAILOSAUR_API_KEY environment variable is not set.
     #
     def initialize(api_key = nil, base_url: 'https://mailosaur.com/')
       resolved_api_key = api_key || ENV['MAILOSAUR_API_KEY']
@@ -77,37 +82,44 @@ module Mailosaur
       @base_url = base_url
     end
 
-    # @return [Analysis] analysis
+    # Operations for analyzing email content and deliverability, including spam scoring.
+    # @return [Analysis] the analysis operations namespace.
     def analysis
       @analysis ||= Analysis.new(connection, method(:handle_http_error))
     end
 
-    # @return [Files] files
+    # Operations for downloading attachments, EML source, and email preview screenshots.
+    # @return [Files] the files operations namespace.
     def files
       @files ||= Files.new(connection, method(:handle_http_error))
     end
 
-    # @return [Messages] messages
+    # Operations for finding, retrieving, creating, and managing email and SMS messages.
+    # @return [Messages] the messages operations namespace.
     def messages
       @messages ||= Messages.new(connection, method(:handle_http_error))
     end
 
-    # @return [Servers] servers
+    # Operations for creating and managing your Mailosaur servers (virtual inboxes).
+    # @return [Servers] the servers operations namespace.
     def servers
       @servers ||= Servers.new(connection, method(:handle_http_error))
     end
 
-    # @return [Usage] usage
+    # Operations for inspecting account usage limits and recent transactional usage.
+    # @return [Usage] the usage operations namespace.
     def usage
       @usage ||= Usage.new(connection, method(:handle_http_error))
     end
 
-    # @return [Devices] devices
+    # Operations for managing virtual security devices and retrieving their one-time passwords.
+    # @return [Devices] the devices operations namespace.
     def devices
       @devices ||= Devices.new(connection, method(:handle_http_error))
     end
 
-    # @return [Previews] previews
+    # Operations for discovering the email clients available for generating email previews.
+    # @return [Previews] the previews operations namespace.
     def previews
       @previews ||= Previews.new(connection, method(:handle_http_error))
     end


### PR DESCRIPTION
## Summary

- Add and expand Intellisense doc comments across the client and operations classes (descriptions, parameters, and return values).
- Adopt **inbox (server)** terminology in the doc-comment prose, so hover documentation matches the dashboard UI.

## Scope

- Doc comments only — no code, public API, or behaviour changes.
- Parameter names, type names, and other code identifiers are unchanged.
